### PR TITLE
Make GKE configuration and context setup optional

### DIFF
--- a/fycli/kubernetes/cli.py
+++ b/fycli/kubernetes/cli.py
@@ -77,7 +77,8 @@ class K8sCLI:
             except KeyError:
                 pass
 
-        self.environment.activate_container_cluster_context()
+        if not os.environ.get('SKIP_KUBECTL_CONFIGURE'):
+            self.environment.activate_container_cluster_context()
 
     def _detect_manifest_dir_type(self):
         fy_deployment_config_file = Path(


### PR DESCRIPTION
As discussed.

We could extend Fy to be able to login to EKS but in this particular case it's unclear whether we'll need to do that or use another agent (and then would arguably need to consider other forms of K8s login which may not be linked to cloud providers). For now the best escape hatch is just to make the GKE login optional.