### PR TITLE
Set the kubectl context even if GCloud is opted out.

### DIFF
--- a/fycli/environment/environment.py
+++ b/fycli/environment/environment.py
@@ -15,6 +15,7 @@ import re
 import string
 from dataclasses import asdict, dataclass, field
 from pathlib import Path, PurePath
+from sh import kubectl
 
 import yaml
 
@@ -164,6 +165,14 @@ class Environment:
 
     def activate_container_cluster_context(self):
         print(f"\n==> activate container cluster credentials\n")
+
+        # If the user has elected to skip GCloud cluster setup, assume
+        # they have already got a context in the environment.
+        if os.environ.get("FY_KUBECTL_CONFIGURE") == "false":
+            self.kubectl_context = kubectl(
+                "config", "current-context").rstrip()
+            return
+
         zone = self._detect_cluster_zone()
         print(
             gcloud.container.clusters(

--- a/fycli/kubernetes/cli.py
+++ b/fycli/kubernetes/cli.py
@@ -77,8 +77,7 @@ class K8sCLI:
             except KeyError:
                 pass
 
-        if not os.environ.get("FY_KUBECTL_CONFIGURE") == "false":
-            self.environment.activate_container_cluster_context()
+        self.environment.activate_container_cluster_context()
 
     def _detect_manifest_dir_type(self):
         fy_deployment_config_file = Path(


### PR DESCRIPTION
The previous PR allowed us to skip gcloud cluster configuration correctly, but unfortunately since the various k8s tooling is always passed an overridden context name (there are about 18 occurrences), all of those commands are broken - they end up with an empty string and that confuses the commands.

Rather than try to make that override parameter optional in all 18 cases, we could keep using it and instead set the current context properly in the environment object metadata. Assuming the user has properly set up the kubectl context externally to Fy already, we can just query it and set the `kubectl_context` variable, allowing the subsequent commands to succeed.