### PR TITLE
Update kube-score k8s version

### DIFF
--- a/fycli/kubernetes/cli.py
+++ b/fycli/kubernetes/cli.py
@@ -561,7 +561,7 @@ class K8sCLI:
                     kube_score(
                         kubectl.kustomize(*kubectl_args),
                         "score",
-                        "--kubernetes-version=v1.14",
+                        "--kubernetes-version=v1.28",
                         "-v",
                         "-",
                         _ok_code=[0, 1],
@@ -579,7 +579,7 @@ class K8sCLI:
                 ):
                     output = kube_score(
                         "score",
-                        "--kubernetes-version=v1.14",
+                        "--kubernetes-version=v1.28",
                         "-v",
                         manifest,
                         _ok_code=[0, 1],


### PR DESCRIPTION
1.14 is pretty ancient at this point, and with most cloud vendors 1.28 is now the earliest supported version. 1.31 has been out for a little bit and that puts 1.28 around a year old at this point.